### PR TITLE
Update group_eligible_assignment_resource_test.go

### DIFF
--- a/internal/provider/group_eligible_assignment_resource_test.go
+++ b/internal/provider/group_eligible_assignment_resource_test.go
@@ -45,7 +45,6 @@ resource "azuread_group" "pag" {
 	display_name       = "azurepim-acc-test-group-pag"
 	owners             = [data.azuread_client_config.current.object_id]
 	security_enabled   = true
-	assignable_to_role = true
 }
 
 resource "azurepim_group_eligible_assignment" "test" {


### PR DESCRIPTION
Removed unused attribute assignable_to_role from test for pag group creation.